### PR TITLE
Fix missing cid errors in CommandBase.

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -181,8 +181,10 @@ class CommandBase extends Command {
       if ($fileinfo['display']) {
         $file = $this->request("{$fileinfo['file']['uri']}.json");
         if (pathinfo($file['url'], PATHINFO_EXTENSION) === 'patch') {
-          $file['cid'] = $fileinfo['file']['cid'];
-          $files[] = $file;
+          if (!empty($fileinfo['file']['cid'])) {
+            $file['cid'] = $fileinfo['file']['cid'];
+            $files[] = $file;
+          }
         }
       }
     }


### PR DESCRIPTION
Error with some items missing cid:

` What issue are you working on? [2785051]:
 > 2785051

PHP Notice:  Undefined index: cid in /home/ar/www/sites/d8.6/issue/src/Command/CommandBase.php on line 184
PHP Stack trace:
PHP   1. {main}() /home/ar/www/sites/d8.6/issue/command:0
PHP   2. Symfony\Component\Console\Application->run($input = *uninitialized*, $output = *uninitialized*) /home/ar/www/sites/d8.6/issue/command:28
PHP   3. Symfony\Component\Console\Application->doRun($input = *uninitialized*, $output = *uninitialized*) /home/ar/www/sites/d8.6/vendor/symfony/console/Application.php:148
PHP   4. Symfony\Component\Console\Application->doRunCommand($command = *uninitialized*, $input = *uninitialized*, $output = *uninitialized*) /home/ar/www/sites/d8.6/vendor/symfony/console/Application.php:248
PHP   5. DrupalIssue\Command\PatchCommand->run($input = *uninitialized*, $output = *uninitialized*) /home/ar/www/sites/d8.6/vendor/symfony/console/Application.php:946
PHP   6. DrupalIssue\Command\PatchCommand->execute($input = *uninitialized*, $output = *uninitialized*) /home/ar/www/sites/d8.6/vendor/symfony/console/Command/Command.php:252
PHP   7. DrupalIssue\Command\PatchCommand->choosePatch($question = *uninitialized*, $issue = *uninitialized*, $io = *uninitialized*, $empty_message = *uninitialized*) /home/ar/www/sites/d8.6/issue/src/Command/PatchCommand.php:57
PHP   8. DrupalIssue\Command\PatchCommand->getPatches($issue = *uninitialized*) /home/ar/www/sites/d8.6/issue/src/Command/CommandBase.php:152
`